### PR TITLE
Update peer dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.0 / 2017-12-08
+
+- Bump `jss` peer dependency version to `^9.0.0`
+- Remove `jss-vendor-prefixer` peer dependency
+
 ## 0.1.0 / 2017-08-07
 
 - First release

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "reset-jss",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1536,15 +1536,6 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -1554,6 +1545,15 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "strip-ansi": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reset-jss",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "JSS port of Meyer's reset.css",
   "author": {
     "name": "Oleg Slobodskoi",
@@ -32,8 +32,7 @@
     "eslint-plugin-react": "^6.8.0"
   },
   "peerDependencies": {
-    "jss": "^8.1.0",
-    "jss-global": "^2.0.0",
-    "jss-vendor-prefixer": "^6.0.0"
+    "jss": "^9.0.0",
+    "jss-global": "^2.0.0"
   }
 }


### PR DESCRIPTION
Here are a few updates on the peer dependencies:
1. Bump `jss` peer dependency version to `^9.0.0` as it is the current version.
2. Remove `jss-vendor-prefixer` peer dependency, because as far as I can see, there aren't any vendor specific rules in this jss reset nor in the original meyer's reset.
